### PR TITLE
Registered Confirmation and registered count on web page

### DIFF
--- a/backend/constants/constants.ts
+++ b/backend/constants/constants.ts
@@ -1,1 +1,1 @@
-export const API_BASE_URL = "http://localhost:3001"; // Adjust when we change backend
+export const API_BASE_URL = "https://redi-app-8ea0a6e9c3d9.herokuapp.com"; // Adjust when we change backend

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,4 +28,5 @@ app.listen(PORT, () => {
   console.log("  GET  /api/users/:netid - Get user by netid");
   console.log("  POST /api/users - Create new user");
   console.log("  POST /api/users/login - User login");
+  console.log("  GET  /api/registered-count - Get number of Cornellians on waitlist");
 });

--- a/backend/src/routes/landing-page.ts
+++ b/backend/src/routes/landing-page.ts
@@ -15,6 +15,23 @@ router.get("/api/landing-emails", async (req, res) => {
   }
 });
 
+// GET the number of users signed up on the wait list
+router.get("/api/registered-count", async (req, res) => {
+  try {
+    const docs = db.collection("stats").doc("global")
+    const snapshot = await docs.get();
+
+    if (!snapshot.exists) {
+      return res.status(404).json({ error: "Stats doc not found" });
+    }
+
+    res.status(200).json(snapshot.data());
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    res.status(500).json({ error: errorMessage });
+  }
+});
+
 // POST a new document
 router.post("/api/landing-emails", async (req, res) => {
   try {
@@ -25,7 +42,7 @@ router.post("/api/landing-emails", async (req, res) => {
     const existingDoc = await db.collection("landing-emails")
       .where("email", "==", data.email.toLowerCase())
       .get();
-    
+
     if (!existingDoc.empty) {
       return res.status(409).json({ error: "Email already exists" });
     }

--- a/redi-web/constants/constants.ts
+++ b/redi-web/constants/constants.ts
@@ -1,1 +1,1 @@
-export const API_BASE_URL = "https://redi-app-8ea0a6e9c3d9.herokuapp.com"; // Adjust when we change backend
+export const API_BASE_URL = "http://localhost:3001"; // Adjust when we change backend

--- a/redi-web/src/api/api.ts
+++ b/redi-web/src/api/api.ts
@@ -29,3 +29,18 @@ export const apiAddEmail = async (email: string): Promise<void> => {
     throw new Error(msg);
   }
 };
+
+// Get Total Amount of Users
+export const getSignedUpCount = async (): Promise<number> => {
+  const res = await fetch(`${API_BASE_URL}/api/registered-count`);
+
+  if (!res.ok) {
+    const msg = `apiGetSignedUpCount failed – status ${res.status}`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+
+  const data = await res.json();
+  console.log(data);
+  return data.userCount;
+};

--- a/redi-web/src/app/page.tsx
+++ b/redi-web/src/app/page.tsx
@@ -213,7 +213,7 @@ export default function Home() {
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
-            strokeWidth="2"
+            stroke-width="2"
             strokeLinecap="round"
             strokeLinejoin="round"
             className="w-8 h-8 text-white"

--- a/redi-web/src/app/page.tsx
+++ b/redi-web/src/app/page.tsx
@@ -1,15 +1,29 @@
 "use client"; // for using useState
 
-import { apiAddEmail, getEmails } from "@/api/api";
+import { apiAddEmail, getEmails, getSignedUpCount } from "@/api/api";
 import Link from "next/link";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 export default function Home() {
   const [email, setEmail] = useState("");
   const [emails, setEmails] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [register, setRegistered] = useState(false);
+  const [signedUpCount, setSignedUpCount] = useState<number>(0);
 
+  useEffect(() => {
+    const fetchCount = async () => {
+      try {
+        const count = await getSignedUpCount();
+
+        setSignedUpCount(count);
+      } catch (error) {
+        console.error("Failed to fetch signed up count:", error);
+      }
+    };
+    fetchCount();
+  }, []);
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!email) return;
@@ -31,8 +45,7 @@ export default function Home() {
 
       await apiAddEmail(email);
       setEmails((prev) => [...prev, email]); // update UI optimistically
-      setEmail(""); // clear input
-      alert("Email added successfully!");
+      setRegistered(true)
     } catch {
       setError("Failed to add email");
     } finally {
@@ -101,32 +114,48 @@ export default function Home() {
           </h2>
         </div>
 
-        <form
-          onSubmit={handleSubmit}
-          className="flex relative w-full md:w-fit md:m-auto"
-        >
-          <input
-            type="email"
-            placeholder="ezra123@cornell.edu"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="rounded-full h-[64px] md:h-[70px] p-1 pl-6 bg-white w-full md:w-[600px] text-[16px] md:text-[20px] placeholder:opacity-50 placeholder:text-black focus:[box-shadow:0_0_0_5px_rgba(255_255_255_/_50%)] focus:outline-none text-black transition"
-          />
-          <button
-            type="submit"
-            className="bg-[linear-gradient(135.7deg,_#000000_0%,_#333333_100.01%)] text-white rounded-full px-6 py-4 text-[16px] md:text-[20px] absolute right-1 top-1 cursor-pointer transform 
+        {register ?
+          (<div className="flex justify-center w-full md:w-fit md:m-auto">
+            <div className="rounded-full h-[64px] md:h-[70px] md:w-[600px] flex items-center justify-center">
+              <p className="text-[20px] md:text-[20px] text-white">
+                Email added – we'll notify you when redi launches
+              </p>
+            </div>
+          </div>
+          )
+          :
+          (
+            <form
+              onSubmit={handleSubmit}
+              className="flex relative w-full md:w-fit md:m-auto"
+            >
+              <input
+                type="email"
+                placeholder="ezra123@cornell.edu"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="rounded-full h-[64px] md:h-[70px] p-1 pl-6 bg-white w-full md:w-[600px] text-[16px] md:text-[20px] placeholder:opacity-50 placeholder:text-black focus:[box-shadow:0_0_0_5px_rgba(255_255_255_/_50%)] focus:outline-none text-black transition"
+              />
+              <button
+                type="submit"
+                className="bg-[linear-gradient(135.7deg,_#000000_0%,_#333333_100.01%)] text-white rounded-full px-6 py-4 text-[16px] md:text-[20px] absolute right-1 top-1 cursor-pointer transform 
             hover:-translate-y-1.5 hover:[box-shadow:0_6px_0_0_rgba(0_0_0_/_60%)] hover:opacity-90
             focus-visible:-translate-y-1.5 focus-visible:[box-shadow:0_6px_0_0_rgba(0_0_0_/_60%)] focus-visible:opacity-90
             focus:outline-none
             active:-translate-y-1 active:[box-shadow:0_4px_0_0_rgba(0_0_0_/_60%)] active:opacity-95
             transition focus-visible:outline-[#006BFF]"
-          >
-            Join waitlist
-          </button>
-        </form>
+              >
+                Join waitlist
+              </button>
+            </form>
+          )
+        }
       </main>
 
+      <h2 className="text-xl md:text-1xl text-white opacity-70">
+        {signedUpCount} Cornellians have already signed up
+      </h2>
       <div className="flex gap-6 justify-center md:[&>div]:w-[200px]">
         <div className="flex flex-col gap-2 items-center">
           <svg


### PR DESCRIPTION
### Summary <!-- Required -->
Removed the alert for registration confirmation in favor of having text shown on the webpage.
Implemented a "live" count of users that have already signed up by creating an additional route and having webpage access this new endpoint.

This pull request is the first step towards implementing registration confirmation text and a viewable count of users on the waitlist.

- [x] implemented registration confirmation text
- [x] implemented viewable count of users


- [X] Updated backend api specification



### Test Plan <!-- Required -->
Tested through local environment by inputting different emails and modifying the "global" registration count.

<!-- Provide screenshots or point out the additional unit tests -->
<img width="720" height="450" alt="image" src="https://github.com/user-attachments/assets/1fe3e52c-2d21-4e19-8ea6-fa3d576ca177" />



- Database schema change (anything that changes Firestore collection structure)
- Created new Collection called "stats" that contains information regarding registration count.
