### PR TITLE
Fixing navigation Fix Authentication and Navigation Issues

### DIFF
--- a/frontend/app/(auth)/(tabs)/profile.tsx
+++ b/frontend/app/(auth)/(tabs)/profile.tsx
@@ -1,6 +1,7 @@
 import AppText from '@/app/components/ui/AppText';
 import Button from '@/app/components/ui/Button';
 import { ProfileResponse } from '@/types';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router } from 'expo-router';
 import {
   Bell,
@@ -142,10 +143,28 @@ export default function ProfileScreen() {
         style: 'destructive',
         onPress: async () => {
           try {
+            console.log('Starting sign out process...');
+
+            // Clear any stored data first
+            await AsyncStorage.clear();
+            console.log('AsyncStorage cleared');
+
+            // Sign out from Firebase
             await signOutUser();
-            router.replace('/home' as any);
-          } catch {
-            Alert.alert('Error', 'Failed to sign out');
+            console.log('Sign out successful');
+
+            // Navigate to the root index page
+            // Use dismiss to go back to root, then replace
+            console.log('Navigating to root...');
+            router.dismissAll();
+            router.replace('/');
+          } catch (error) {
+            console.error('Sign out error:', error);
+            Alert.alert(
+              'Error',
+              'Failed to sign out: ' +
+                (error instanceof Error ? error.message : 'Unknown error')
+            );
           }
         },
       },

--- a/frontend/app/(auth)/_layout.tsx
+++ b/frontend/app/(auth)/_layout.tsx
@@ -20,6 +20,12 @@ export default function AuthLayout() {
           presentation: 'modal',
         }}
       />
+      <Stack.Screen
+        name="(tabs)"
+        options={{
+          headerShown: false,
+        }}
+      />
     </Stack>
   );
 }

--- a/frontend/app/(auth)/home.tsx
+++ b/frontend/app/(auth)/home.tsx
@@ -16,7 +16,9 @@ import {
   signInUser,
   signUpUser,
   validateCornellEmail,
+  getCurrentUser,
 } from '../api/authService';
+import { getCurrentUserProfile } from '../api/profileApi';
 import { AppColors } from '../components/AppColors';
 import LegalFooterText from '../components/onboarding/LegalFooterText';
 import AppInput from '../components/ui/AppInput';
@@ -85,16 +87,20 @@ export default function HomePage() {
     try {
       await signInUser(email, password);
 
-      // Check onboarding completion status
-      const onboardingComplete = await AsyncStorage.getItem(
-        'onboarding_complete'
-      );
+      // Get the current user's Firebase UID
+      const user = getCurrentUser();
+      if (!user?.uid) {
+        throw new Error('Authentication failed. Please try again.');
+      }
 
-      if (onboardingComplete === 'true') {
-        // User has completed onboarding, go to main app
+      // Check if user has a profile in the database
+      const profile = await getCurrentUserProfile(user.uid);
+
+      if (profile) {
+        // User has a complete profile, go to main app
         router.replace('/(auth)/(tabs)');
       } else {
-        // User hasn't completed onboarding, go to create profile
+        // User doesn't have a profile yet, go to create profile
         router.replace('/(auth)/create-profile');
       }
     } catch (error) {

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,8 +1,8 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { getCurrentUser } from './api/authService';
+import { getCurrentUserProfile } from './api/profileApi';
 import { AppColors } from './components/AppColors';
 import AppText from './components/ui/AppText';
 import Button from './components/ui/Button';
@@ -16,16 +16,14 @@ export default function Index() {
         const user = getCurrentUser();
 
         if (user) {
-          // User is authenticated, check onboarding status
-          const onboardingComplete = await AsyncStorage.getItem(
-            'onboarding_complete'
-          );
+          // User is authenticated, check if they have a profile
+          const profile = await getCurrentUserProfile(user.uid);
 
-          if (onboardingComplete === 'true') {
-            // User has completed onboarding, go to main app
+          if (profile) {
+            // User has a complete profile, go to main app
             router.replace('/(auth)/(tabs)');
           } else {
-            // User hasn't completed onboarding, go to create profile
+            // User doesn't have a profile yet, go to create profile
             router.replace('/(auth)/create-profile');
           }
         } else {


### PR DESCRIPTION
### Summary <!-- Required -->

  Fixes two authentication/navigation bugs that were preventing proper user flow:
  1. Users without profiles were incorrectly routed to the main app instead of onboarding
  2. Sign out wasn't navigating users back to the auth/landing page

###Issues Fixed

  Issue #1: Incorrect Routing for Users Without Profiles

  Problem: When a user created an account but exited before completing onboarding (Firebase auth account exists but no profile in database), they were incorrectly routed to the home/match page when logging back in instead of being sent back to the onboarding flow.

  Here's the text with the awkward line breaks removed:
Root Cause: The app was checking AsyncStorage for an onboarding_complete flag instead of verifying actual profile existence in the database via the API.
Solution:

Replaced AsyncStorage checks with API calls to getCurrentUserProfile()
Now properly checks database for profile existence after login
Routes users based on actual data state, not local storage flags

Issue #2: Sign Out Not Navigating to Landing Page
Problem: When users tapped sign out, they remained stuck in the (auth) group and were redirected to the matches page instead of the landing/auth page.
Root Cause:

Navigation stack wasn't being properly cleared before redirecting
Missing (tabs) screen declaration in auth group layout caused routing confusion
Race condition between auth state change and navigation

Solution:

Added router.dismissAll() to clear navigation stack before sign out redirect
Added (tabs) screen to (auth)/_layout.tsx for proper route registration
Enhanced auth state listener with better logging for debugging
Improved sign out flow with proper async handling

Changes Made

Authentication Flow Updates

frontend/app/(auth)/home.tsx

Added imports for getCurrentUser and getCurrentUserProfile
Updated handleLogin() to check profile existence via API instead of AsyncStorage
Routes to /(auth)/(tabs) if profile exists, /(auth)/create-profile if not

frontend/app/_layout.tsx

Replaced AsyncStorage dependency with getCurrentUserProfile() API calls
Root layout now checks actual database for profile existence

frontend/app/index.tsx

Removed AsyncStorage dependency
Added getCurrentUserProfile() check for proper routing on app launch


Sign Out Navigation Fixes

frontend/app/(auth)/(tabs)/profile.tsx

Updated handleSignOut() to use router.dismissAll() before navigation
Clears AsyncStorage before Firebase sign out

frontend/app/(auth)/_layout.tsx

Added missing (tabs) screen declaration to Stack navigator
Ensures Expo Router properly recognizes tab navigator in route hierarchy

###Technical Details
Authentication State Flow
User Login:

Firebase authentication succeeds
Get user's Firebase UID
Call getCurrentUserProfile(uid)
If profile exists → /(auth)/(tabs) (main app)
If profile is null → /(auth)/create-profile (onboarding)

User Sign Out:

Clear AsyncStorage
Sign out from Firebase (triggers auth state change)
Clear navigation stack with router.dismissAll()
Navigate to / (landing page)
Auth listener detects user = null + inAuthGroup = true
Confirms navigation to root index

###Testing
Manual Testing Steps

New user signup → completes onboarding → sees main app
New user signup → exits before onboarding → logs back in → sees onboarding
Existing user with profile → login → sees main app
User signs out from profile page → sees landing page
User signs out → cannot access protected routes
Tab navigation works normally (no interference from auth logic)

###Notes

Console logs added for debugging can be removed in future cleanup PR