### PR TITLE
Cleaned up onboarding flow and removed match card placeholders

### DIFF
--- a/frontend/app/(auth)/(tabs)/index.tsx
+++ b/frontend/app/(auth)/(tabs)/index.tsx
@@ -1,11 +1,7 @@
 // Main Home Screen — Card-based daily engagement
-import { getCurrentUser } from '@/app/api/authService';
-import { getConversations } from '@/app/api/chatApi';
 import {
-  getActivePrompt,
   getBatchMatchData,
   getMatchHistory,
-  getPromptAnswer,
   submitPromptAnswer,
 } from '@/app/api/promptsApi';
 import { AppColors } from '@/app/components/AppColors';
@@ -20,7 +16,6 @@ import ListItemWrapper from '@/app/components/ui/ListItemWrapper';
 import Sheet from '@/app/components/ui/Sheet';
 import { useThemeAware } from '@/app/contexts/ThemeContext';
 import {
-  MOCK_MATCH_CARDS,
   PREFERENCE_CARDS,
   PROFILE_ACTION_CARDS,
   WEEKLY_PROMPT_CARDS,
@@ -31,12 +26,10 @@ import {
   NudgeStatusResponse,
   ProfileResponse,
   WeeklyMatchResponse,
-  WeeklyPromptAnswerResponse,
   WeeklyPromptResponse,
 } from '@/types';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Check,
   Heart,
@@ -55,6 +48,7 @@ import React, {
   useState,
 } from 'react';
 import { StatusBar, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const TOUR_STORAGE_KEY = 'home_tour_seen_v1';
 
@@ -141,11 +135,6 @@ export default function HomeScreen() {
   );
   const [userAnswer, setUserAnswer] = useState<string>('');
   const [currentMatches, setCurrentMatches] = useState<MatchWithProfile[]>([]);
-  // ── TEMPORARY PLACEHOLDER ────────────────────────────────────────────────────
-  // Seeds match cards from existing chat conversations so the card stack isn't
-  // empty during development. Remove once the real match pipeline is wired up.
-  const [chatMatchCards, setChatMatchCards] = useState<DailyCard[]>([]);
-  // ─────────────────────────────────────────────────────────────────────────────
   const [showPromptSheet, setShowPromptSheet] = useState(false);
   const [showFilterSheet, setShowFilterSheet] = useState(false);
   const [activeFilter, setActiveFilter] = useState<
@@ -256,34 +245,6 @@ export default function HomeScreen() {
       } catch {
         setCurrentMatches([]);
       }
-
-      // ── TEMPORARY PLACEHOLDER ───────────────────────────────────────────────
-      // Builds match cards from existing chat conversations for dev/testing.
-      // Remove this block once the real weekly-match pipeline populates the feed.
-      try {
-        const convos = await getConversations();
-        const currentUid = getCurrentUser()?.uid;
-        const cards: DailyCard[] = convos
-          .filter((c) => c.lastMessage)
-          .flatMap((c) => {
-            const otherUid = c.participantIds.find((id) => id !== currentUid);
-            if (!otherUid) return [];
-            const other = c.participants[otherUid];
-            if (!other || other.deleted) return [];
-            return [
-              {
-                id: `chat-match-${c.id}`,
-                type: 'match' as const,
-                matchName: other.name,
-                matchImage: other.image ?? undefined,
-              },
-            ];
-          });
-        setChatMatchCards(cards);
-      } catch {
-        // Non-critical — silently ignore
-      }
-      // ────────────────────────────────────────────────────────────────────────
     } catch (error) {
       console.error('Error loading data:', error);
     }
@@ -328,26 +289,19 @@ export default function HomeScreen() {
           nudgeStatus: m.nudgeStatus,
         };
       });
-    // Fallback chain: real API matches → chat contacts (temp) → static mocks
-    const matchCards: DailyCard[] =
-      apiMatchCards.length > 0
-        ? apiMatchCards
-        : chatMatchCards.length > 0
-          ? chatMatchCards
-          : MOCK_MATCH_CARDS;
 
     const profileCards = PROFILE_ACTION_CARDS.filter((c) => !c.completed);
     const result: DailyCard[] = [];
     const maxLen = Math.max(
       profileCards.length,
       PREFERENCE_CARDS.length,
-      matchCards.length,
+      apiMatchCards.length,
       WEEKLY_PROMPT_CARDS.length
     );
     for (let i = 0; i < maxLen; i++) {
       if (i < profileCards.length) result.push(profileCards[i]);
       if (i < PREFERENCE_CARDS.length) result.push(PREFERENCE_CARDS[i]);
-      if (i < matchCards.length) result.push(matchCards[i]);
+      if (i < apiMatchCards.length) result.push(apiMatchCards[i]);
       if (i < WEEKLY_PROMPT_CARDS.length) result.push(WEEKLY_PROMPT_CARDS[i]);
     }
 
@@ -358,7 +312,7 @@ export default function HomeScreen() {
     const filtered =
       activeFilter === 'all' ? all : all.filter((c) => c.type === activeFilter);
     return tourSeen ? filtered : [...TUTORIAL_CARDS, ...filtered];
-  }, [currentMatches, chatMatchCards, activeFilter, tourSeen]);
+  }, [currentMatches, activeFilter, tourSeen]);
 
   return (
     <View style={styles.container}>
@@ -406,7 +360,9 @@ export default function HomeScreen() {
       </View>
 
       {/* Card stack — flex:1 so it fills remaining space */}
-      <View style={[styles.stackContainer, { paddingBottom: 32 + insets.bottom }]}>
+      <View
+        style={[styles.stackContainer, { paddingBottom: 32 + insets.bottom }]}
+      >
         <CardStack
           key={`${activeFilter}-${tourSeen}`}
           cards={dailyCards}

--- a/frontend/app/(auth)/create-profile.tsx
+++ b/frontend/app/(auth)/create-profile.tsx
@@ -1,5 +1,4 @@
 import {
-  ETHNICITY_OPTIONS,
   GENDER_OPTIONS,
   INTERESTED_IN_OPTIONS,
   PRONOUN_OPTIONS,
@@ -60,7 +59,7 @@ import {
   validateProfilePayload,
 } from '../utils/onboardingTransform';
 
-const TOTAL_STEPS = 15; // Steps 2-16 (Step 1 is in home.tsx)
+const TOTAL_STEPS = 10; // Steps 2-11 (Step 1 is in home.tsx)
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const PROMPT_ITEM_HEIGHT = 120; // Approximate height of a prompt selector
 
@@ -218,11 +217,7 @@ export default function CreateProfileScreen() {
       return;
     }
 
-    if (currentStep === 14) {
-      normalizeSocialMediaLinks();
-    }
-
-    if (currentStep < 16) {
+    if (currentStep < 11) {
       setDirection('forward');
       setCurrentStep(currentStep + 1);
     } else {
@@ -237,82 +232,6 @@ export default function CreateProfileScreen() {
     } else if (currentStep === 2) {
       // Go back to home/signup screen
       router.replace('/home' as any);
-    }
-  };
-
-  const normalizeSocialMediaLinks = () => {
-    // Normalize LinkedIn
-    if (data.linkedIn) {
-      let linkedin = data.linkedIn.trim();
-      // Remove @ if present
-      linkedin = linkedin.replace(/^@/, '');
-      // Remove https:// or http:// if present
-      linkedin = linkedin.replace(/^https?:\/\//, '');
-      // Remove www. if present
-      linkedin = linkedin.replace(/^www\./, '');
-      // If it doesn't start with linkedin.com, add it
-      if (!linkedin.startsWith('linkedin.com/')) {
-        // If it's just a username, add the full path
-        if (!linkedin.includes('/')) {
-          linkedin = `linkedin.com/in/${linkedin}`;
-        } else {
-          linkedin = `linkedin.com/${linkedin}`;
-        }
-      }
-      updateField('linkedIn', `https://${linkedin}`);
-    }
-
-    // Normalize Instagram - extract username only
-    if (data.instagram) {
-      let instagram = data.instagram.trim();
-      // Remove @ if present
-      instagram = instagram.replace(/^@/, '');
-      // Remove https:// or http:// if present
-      instagram = instagram.replace(/^https?:\/\//, '');
-      // Remove www. if present
-      instagram = instagram.replace(/^www\./, '');
-      // Remove instagram.com/ if present
-      instagram = instagram.replace(/^instagram\.com\//, '');
-      // Store just the username (backend expects username only)
-      updateField('instagram', instagram);
-    }
-
-    // Normalize Snapchat - extract username only
-    if (data.snapchat) {
-      let snapchat = data.snapchat.trim();
-      // Remove @ if present
-      snapchat = snapchat.replace(/^@/, '');
-      // Remove https:// or http:// if present
-      snapchat = snapchat.replace(/^https?:\/\//, '');
-      // Remove www. if present
-      snapchat = snapchat.replace(/^www\./, '');
-      // Remove snapchat.com/add/ if present
-      snapchat = snapchat.replace(/^snapchat\.com\/add\//, '');
-      // Store just the username (backend expects username only)
-      updateField('snapchat', snapchat);
-    }
-
-    // Normalize GitHub - extract username only
-    if (data.github) {
-      let github = data.github.trim();
-      // Remove @ if present
-      github = github.replace(/^@/, '');
-      // Remove https:// or http:// if present
-      github = github.replace(/^https?:\/\//, '');
-      // Remove www. if present
-      github = github.replace(/^www\./, '');
-      // Remove github.com/ if present
-      github = github.replace(/^github\.com\//, '');
-      // Store just the username (backend expects username only)
-      updateField('github', github);
-    }
-
-    // Normalize Website (ensure it has https://)
-    if (data.website) {
-      let website = data.website.trim();
-      if (!website.startsWith('http://') && !website.startsWith('https://')) {
-        updateField('website', `https://${website}`);
-      }
     }
   };
 
@@ -685,66 +604,66 @@ export default function CreateProfileScreen() {
           </View>
         );
 
+      // case 9:
+      //   return (
+      //     <View style={styles.stepContainer}>
+      //       <OnboardingTitle
+      //         title="What's your ethnicity?"
+      //         subtitle="Optional - this helps you connect with people who share similar cultural backgrounds."
+      //       />
+      //       <ListItemWrapper>
+      //         {ETHNICITY_OPTIONS.map((ethnicity) => {
+      //           const isPreferNotToSay = ethnicity === 'Prefer not to say';
+      //           const hasPreferNotToSay =
+      //             data.ethnicity?.includes('Prefer not to say');
+      //           const hasOtherEthnicity =
+      //             data.ethnicity &&
+      //             data.ethnicity.some((e) => e !== 'Prefer not to say');
+
+      //           // Disable "Prefer not to say" if other ethnicities are selected
+      //           // Disable other ethnicities if "Prefer not to say" is selected
+      //           const isDisabled = isPreferNotToSay
+      //             ? hasOtherEthnicity
+      //             : hasPreferNotToSay;
+
+      //           return (
+      //             <ListItem
+      //               key={ethnicity}
+      //               title={ethnicity}
+      //               selected={data.ethnicity?.includes(ethnicity)}
+      //               disabled={isDisabled}
+      //               onPress={() => {
+      //                 if (isPreferNotToSay) {
+      //                   // If clicking "Prefer not to say", toggle it exclusively
+      //                   if (hasPreferNotToSay) {
+      //                     // Already selected, unselect it
+      //                     updateField('ethnicity', []);
+      //                   } else {
+      //                     // Not selected, set it exclusively
+      //                     updateField('ethnicity', ['Prefer not to say']);
+      //                   }
+      //                 } else {
+      //                   // If clicking other ethnicity and "Prefer not to say" is selected, remove it first
+      //                   if (hasPreferNotToSay) {
+      //                     updateField('ethnicity', [ethnicity]);
+      //                   } else {
+      //                     toggleArrayItem('ethnicity', ethnicity);
+      //                   }
+      //                 }
+      //               }}
+      //               right={
+      //                 data.ethnicity?.includes(ethnicity) ? (
+      //                   <Check size={20} color={AppColors.accentDefault} />
+      //                 ) : null
+      //               }
+      //             />
+      //           );
+      //         })}
+      //       </ListItemWrapper>
+      //     </View>
+      //   );
+
       case 9:
-        return (
-          <View style={styles.stepContainer}>
-            <OnboardingTitle
-              title="What's your ethnicity?"
-              subtitle="Optional - this helps you connect with people who share similar cultural backgrounds."
-            />
-            <ListItemWrapper>
-              {ETHNICITY_OPTIONS.map((ethnicity) => {
-                const isPreferNotToSay = ethnicity === 'Prefer not to say';
-                const hasPreferNotToSay =
-                  data.ethnicity?.includes('Prefer not to say');
-                const hasOtherEthnicity =
-                  data.ethnicity &&
-                  data.ethnicity.some((e) => e !== 'Prefer not to say');
-
-                // Disable "Prefer not to say" if other ethnicities are selected
-                // Disable other ethnicities if "Prefer not to say" is selected
-                const isDisabled = isPreferNotToSay
-                  ? hasOtherEthnicity
-                  : hasPreferNotToSay;
-
-                return (
-                  <ListItem
-                    key={ethnicity}
-                    title={ethnicity}
-                    selected={data.ethnicity?.includes(ethnicity)}
-                    disabled={isDisabled}
-                    onPress={() => {
-                      if (isPreferNotToSay) {
-                        // If clicking "Prefer not to say", toggle it exclusively
-                        if (hasPreferNotToSay) {
-                          // Already selected, unselect it
-                          updateField('ethnicity', []);
-                        } else {
-                          // Not selected, set it exclusively
-                          updateField('ethnicity', ['Prefer not to say']);
-                        }
-                      } else {
-                        // If clicking other ethnicity and "Prefer not to say" is selected, remove it first
-                        if (hasPreferNotToSay) {
-                          updateField('ethnicity', [ethnicity]);
-                        } else {
-                          toggleArrayItem('ethnicity', ethnicity);
-                        }
-                      }
-                    }}
-                    right={
-                      data.ethnicity?.includes(ethnicity) ? (
-                        <Check size={20} color={AppColors.accentDefault} />
-                      ) : null
-                    }
-                  />
-                );
-              })}
-            </ListItemWrapper>
-          </View>
-        );
-
-      case 10:
         return (
           <View style={styles.stepContainer}>
             <OnboardingTitle
@@ -769,7 +688,7 @@ export default function CreateProfileScreen() {
           </View>
         );
 
-      case 11:
+      case 10:
         return (
           <View style={styles.stepContainer}>
             <OnboardingTitle
@@ -785,241 +704,241 @@ export default function CreateProfileScreen() {
           </View>
         );
 
-      case 12:
-        return (
-          <View style={styles.stepContainer}>
-            <OnboardingTitle
-              title="Select 1-3 prompts for your profile"
-              subtitle="Optional - Add prompts for fun conversation starters."
-            />
-            <View style={styles.promptsContainer}>
-              {data.prompts.map((prompt, index) => {
-                const isDragging = draggingPromptIndex === index;
-                const shouldShowGhost =
-                  hoverPromptIndex === index &&
-                  draggingPromptIndex !== null &&
-                  draggingPromptIndex !== hoverPromptIndex;
+      // case 12:
+      //   return (
+      //     <View style={styles.stepContainer}>
+      //       <OnboardingTitle
+      //         title="Select 1-3 prompts for your profile"
+      //         subtitle="Optional - Add prompts for fun conversation starters."
+      //       />
+      //       <View style={styles.promptsContainer}>
+      //         {data.prompts.map((prompt, index) => {
+      //           const isDragging = draggingPromptIndex === index;
+      //           const shouldShowGhost =
+      //             hoverPromptIndex === index &&
+      //             draggingPromptIndex !== null &&
+      //             draggingPromptIndex !== hoverPromptIndex;
 
-                return (
-                  <View key={prompt.id} style={styles.promptItemWrapper}>
-                    {shouldShowGhost && draggingPromptIndex !== null && (
-                      <View style={styles.promptGhostPlaceholder}>
-                        <View style={styles.promptWithHandle}>
-                          <View style={styles.promptDragHandle}>
-                            <GripVertical
-                              size={20}
-                              color={AppColors.foregroundDimmer}
-                            />
-                          </View>
-                          <View
-                            style={[
-                              styles.promptSelectorContainer,
-                              { opacity: 0.3 },
-                            ]}
-                          >
-                            <PromptSelector
-                              prompt={data.prompts[draggingPromptIndex]}
-                              onUpdate={() => {}}
-                              onRemove={() => {}}
-                              canRemove={true}
-                            />
-                          </View>
-                        </View>
-                      </View>
-                    )}
-                    <DraggablePromptSelector
-                      prompt={prompt}
-                      index={index}
-                      isDragging={isDragging}
-                      onUpdate={(updated) => updatePrompt(prompt.id, updated)}
-                      onRemove={() => removePrompt(prompt.id)}
-                      onDragStart={() => setDraggingPromptIndex(index)}
-                      onDragEnd={(toIndex) => {
-                        reorderPrompts(index, toIndex);
-                        setDraggingPromptIndex(null);
-                        setHoverPromptIndex(null);
-                      }}
-                      onHoverChange={setHoverPromptIndex}
-                      canRemove={true}
-                      totalPrompts={data.prompts.length}
-                      onHaptic={() => haptic.medium()}
-                    />
-                  </View>
-                );
-              })}
-              {data.prompts.length < 3 && (
-                <Button
-                  title={
-                    data.prompts.length === 0 ? 'Select prompt' : 'Add prompt'
-                  }
-                  onPress={addPrompt}
-                  variant="secondary"
-                  fullWidth
-                  iconLeft={Plus}
-                />
-              )}
-            </View>
-          </View>
-        );
+      //           return (
+      //             <View key={prompt.id} style={styles.promptItemWrapper}>
+      //               {shouldShowGhost && draggingPromptIndex !== null && (
+      //                 <View style={styles.promptGhostPlaceholder}>
+      //                   <View style={styles.promptWithHandle}>
+      //                     <View style={styles.promptDragHandle}>
+      //                       <GripVertical
+      //                         size={20}
+      //                         color={AppColors.foregroundDimmer}
+      //                       />
+      //                     </View>
+      //                     <View
+      //                       style={[
+      //                         styles.promptSelectorContainer,
+      //                         { opacity: 0.3 },
+      //                       ]}
+      //                     >
+      //                       <PromptSelector
+      //                         prompt={data.prompts[draggingPromptIndex]}
+      //                         onUpdate={() => {}}
+      //                         onRemove={() => {}}
+      //                         canRemove={true}
+      //                       />
+      //                     </View>
+      //                   </View>
+      //                 </View>
+      //               )}
+      //               <DraggablePromptSelector
+      //                 prompt={prompt}
+      //                 index={index}
+      //                 isDragging={isDragging}
+      //                 onUpdate={(updated) => updatePrompt(prompt.id, updated)}
+      //                 onRemove={() => removePrompt(prompt.id)}
+      //                 onDragStart={() => setDraggingPromptIndex(index)}
+      //                 onDragEnd={(toIndex) => {
+      //                   reorderPrompts(index, toIndex);
+      //                   setDraggingPromptIndex(null);
+      //                   setHoverPromptIndex(null);
+      //                 }}
+      //                 onHoverChange={setHoverPromptIndex}
+      //                 canRemove={true}
+      //                 totalPrompts={data.prompts.length}
+      //                 onHaptic={() => haptic.medium()}
+      //               />
+      //             </View>
+      //           );
+      //         })}
+      //         {data.prompts.length < 3 && (
+      //           <Button
+      //             title={
+      //               data.prompts.length === 0 ? 'Select prompt' : 'Add prompt'
+      //             }
+      //             onPress={addPrompt}
+      //             variant="secondary"
+      //             fullWidth
+      //             iconLeft={Plus}
+      //           />
+      //         )}
+      //       </View>
+      //     </View>
+      //   );
 
-      case 13:
-        return (
-          <View style={styles.stepContainer}>
-            <OnboardingTitle
-              title="What clubs are you in?"
-              subtitle="Optional - Add any Cornell clubs or organizations you're a part of."
-            />
+      // case 13:
+      //   return (
+      //     <View style={styles.stepContainer}>
+      //       <OnboardingTitle
+      //         title="What clubs are you in?"
+      //         subtitle="Optional - Add any Cornell clubs or organizations you're a part of."
+      //       />
 
-            {data.clubs.length > 0 && (
-              <View style={styles.majorTags}>
-                {data.clubs.map((club, index) => (
-                  <Tag
-                    key={club}
-                    label={club}
-                    dismissible
-                    onDismiss={() => removeClub(index)}
-                  />
-                ))}
-              </View>
-            )}
+      //       {data.clubs.length > 0 && (
+      //         <View style={styles.majorTags}>
+      //           {data.clubs.map((club, index) => (
+      //             <Tag
+      //               key={club}
+      //               label={club}
+      //               dismissible
+      //               onDismiss={() => removeClub(index)}
+      //             />
+      //           ))}
+      //         </View>
+      //       )}
 
-            <Button
-              title="Add club"
-              iconLeft={Plus}
-              onPress={() => setShowClubInput(true)}
-              variant="secondary"
-            />
+      //       <Button
+      //         title="Add club"
+      //         iconLeft={Plus}
+      //         onPress={() => setShowClubInput(true)}
+      //         variant="secondary"
+      //       />
 
-            <Sheet
-              visible={showClubInput}
-              onDismiss={() => {
-                setShowClubInput(false);
-                setClubInput('');
-              }}
-              title="Add club"
-              bottomRound={false}
-            >
-              <View style={styles.majorSheetContent}>
-                <AppInput
-                  autoFocus
-                  placeholder="Enter club name"
-                  value={clubInput}
-                  onChangeText={setClubInput}
-                  autoCapitalize="words"
-                  returnKeyType="done"
-                  onSubmitEditing={addClub}
-                />
-                <Button
-                  title="Add"
-                  onPress={addClub}
-                  variant="primary"
-                  fullWidth
-                  iconLeft={Plus}
-                />
-              </View>
-            </Sheet>
-          </View>
-        );
+      //       <Sheet
+      //         visible={showClubInput}
+      //         onDismiss={() => {
+      //           setShowClubInput(false);
+      //           setClubInput('');
+      //         }}
+      //         title="Add club"
+      //         bottomRound={false}
+      //       >
+      //         <View style={styles.majorSheetContent}>
+      //           <AppInput
+      //             autoFocus
+      //             placeholder="Enter club name"
+      //             value={clubInput}
+      //             onChangeText={setClubInput}
+      //             autoCapitalize="words"
+      //             returnKeyType="done"
+      //             onSubmitEditing={addClub}
+      //           />
+      //           <Button
+      //             title="Add"
+      //             onPress={addClub}
+      //             variant="primary"
+      //             fullWidth
+      //             iconLeft={Plus}
+      //           />
+      //         </View>
+      //       </Sheet>
+      //     </View>
+      //   );
 
-      case 14:
-        return (
-          <View style={styles.stepContainer}>
-            <OnboardingTitle
-              title="Connect your social media"
-              subtitle="All fields are optional - add any you'd like to share"
-            />
-            <AppInput
-              label="Instagram"
-              placeholder="@username"
-              value={data.instagram}
-              onChangeText={(text) => updateField('instagram', text)}
-            />
-            <AppInput
-              label="Snapchat"
-              placeholder="username"
-              value={data.snapchat}
-              onChangeText={(text) => updateField('snapchat', text)}
-            />
-            <AppInput
-              label="LinkedIn"
-              placeholder="linkedin.com/in/username"
-              value={data.linkedIn}
-              onChangeText={(text) => updateField('linkedIn', text)}
-            />
-            <AppInput
-              label="GitHub"
-              placeholder="github.com/username"
-              value={data.github}
-              onChangeText={(text) => updateField('github', text)}
-            />
-            <AppInput
-              label="Personal Website"
-              placeholder="https://yourwebsite.com"
-              value={data.website}
-              onChangeText={(text) => updateField('website', text)}
-            />
-          </View>
-        );
+      // case 14:
+      //   return (
+      //     <View style={styles.stepContainer}>
+      //       <OnboardingTitle
+      //         title="Connect your social media"
+      //         subtitle="All fields are optional - add any you'd like to share"
+      //       />
+      //       <AppInput
+      //         label="Instagram"
+      //         placeholder="@username"
+      //         value={data.instagram}
+      //         onChangeText={(text) => updateField('instagram', text)}
+      //       />
+      //       <AppInput
+      //         label="Snapchat"
+      //         placeholder="username"
+      //         value={data.snapchat}
+      //         onChangeText={(text) => updateField('snapchat', text)}
+      //       />
+      //       <AppInput
+      //         label="LinkedIn"
+      //         placeholder="linkedin.com/in/username"
+      //         value={data.linkedIn}
+      //         onChangeText={(text) => updateField('linkedIn', text)}
+      //       />
+      //       <AppInput
+      //         label="GitHub"
+      //         placeholder="github.com/username"
+      //         value={data.github}
+      //         onChangeText={(text) => updateField('github', text)}
+      //       />
+      //       <AppInput
+      //         label="Personal Website"
+      //         placeholder="https://yourwebsite.com"
+      //         value={data.website}
+      //         onChangeText={(text) => updateField('website', text)}
+      //       />
+      //     </View>
+      //   );
 
-      case 15:
-        return (
-          <View style={styles.stepContainer}>
-            <OnboardingTitle
-              title="What are your interests?"
-              subtitle="Share what you're passionate about"
-            />
+      // case 15:
+      //   return (
+      //     <View style={styles.stepContainer}>
+      //       <OnboardingTitle
+      //         title="What are your interests?"
+      //         subtitle="Share what you're passionate about"
+      //       />
 
-            {data.interests.length > 0 && (
-              <View style={styles.majorTags}>
-                {data.interests.map((interest, index) => (
-                  <Tag
-                    key={interest}
-                    label={interest}
-                    dismissible
-                    onDismiss={() => removeInterest(index)}
-                  />
-                ))}
-              </View>
-            )}
+      //       {data.interests.length > 0 && (
+      //         <View style={styles.majorTags}>
+      //           {data.interests.map((interest, index) => (
+      //             <Tag
+      //               key={interest}
+      //               label={interest}
+      //               dismissible
+      //               onDismiss={() => removeInterest(index)}
+      //             />
+      //           ))}
+      //         </View>
+      //       )}
 
-            <Button
-              title="Add interest"
-              iconLeft={Plus}
-              onPress={() => setShowInterestInput(true)}
-              variant="secondary"
-            />
+      //       <Button
+      //         title="Add interest"
+      //         iconLeft={Plus}
+      //         onPress={() => setShowInterestInput(true)}
+      //         variant="secondary"
+      //       />
 
-            <Sheet
-              visible={showInterestInput}
-              onDismiss={() => {
-                setShowInterestInput(false);
-                setInterestInput('');
-              }}
-              title="Add interest"
-              bottomRound={false}
-            >
-              <View style={styles.majorSheetContent}>
-                <AppInput
-                  autoFocus
-                  placeholder="Enter an interest"
-                  value={interestInput}
-                  onChangeText={setInterestInput}
-                  returnKeyType="done"
-                  onSubmitEditing={addInterest}
-                />
-                <Button
-                  title="Add"
-                  onPress={addInterest}
-                  variant="primary"
-                  fullWidth
-                  iconLeft={Plus}
-                />
-              </View>
-            </Sheet>
-          </View>
-        );
+      //       <Sheet
+      //         visible={showInterestInput}
+      //         onDismiss={() => {
+      //           setShowInterestInput(false);
+      //           setInterestInput('');
+      //         }}
+      //         title="Add interest"
+      //         bottomRound={false}
+      //       >
+      //         <View style={styles.majorSheetContent}>
+      //           <AppInput
+      //             autoFocus
+      //             placeholder="Enter an interest"
+      //             value={interestInput}
+      //             onChangeText={setInterestInput}
+      //             returnKeyType="done"
+      //             onSubmitEditing={addInterest}
+      //           />
+      //           <Button
+      //             title="Add"
+      //             onPress={addInterest}
+      //             variant="primary"
+      //             fullWidth
+      //             iconLeft={Plus}
+      //           />
+      //         </View>
+      //       </Sheet>
+      //     </View>
+      //   );
 
-      case 16:
+      case 11:
         return (
           <View style={styles.stepContainer}>
             <AppText variant="title" style={{ textAlign: 'center' }}>
@@ -1048,7 +967,7 @@ export default function CreateProfileScreen() {
   const getNextLabel = () => {
     if (uploadingImages) return 'Uploading images...';
     if (isSubmitting) return 'Creating profile...';
-    if (currentStep === 16) return 'Get started';
+    if (currentStep === 11) return 'Get started';
     return 'Next';
   };
 
@@ -1080,7 +999,7 @@ export default function CreateProfileScreen() {
     if (currentStep === 6) updateField('showCollegeOnProfile', checked);
     if (currentStep === 8)
       updateField('showSexualOrientationOnProfile', checked);
-    if (currentStep === 9) updateField('showEthnicityOnProfile', checked);
+    //if (currentStep === 9) updateField('showEthnicityOnProfile', checked);
   };
 
   return (

--- a/frontend/app/hooks/useOnboardingState.ts
+++ b/frontend/app/hooks/useOnboardingState.ts
@@ -158,41 +158,15 @@ export function useOnboardingState() {
         return data.sexualOrientation.length > 0;
 
       case 9:
-        // Ethnicity: select at least one
-        return Array.isArray(data.ethnicity) && data.ethnicity.length > 0;
-
-      case 10:
         // Interested in: At least one selected
         return data.interestedIn.length > 0;
 
+      case 10:
+        // Photos: optional for now
+        return true;
+
       case 11:
-        // Photos: 3-6 photos required
-        // return data.pictures.length >= 3 && data.pictures.length <= 6;
-        return true;
-
-      case 12:
-        // Prompts: 1-3 prompts required, each with answer
-        // const validPrompts = data.prompts.filter(
-        //   (p) => p.question && p.answer.trim() !== ''
-        // );
-        // return validPrompts.length >= 1 && validPrompts.length <= 3;
-        return true;
-
-      case 13:
-        // Clubs: Optional, always valid
-        return true;
-
-      case 14:
-        // Social Links: Optional, always valid
-        // Could add URL validation here if needed
-        return true;
-
-      case 15:
-        // Interests: Optional, always valid
-        return true;
-
-      case 16:
-        // Final welcome screen: Always valid
+        // Welcome screen: always valid
         return true;
 
       default:


### PR DESCRIPTION
### Summary

Took training wheels off Match Cards (Following up on my implementation in Clement's 'swiping' PR): 
- Removed chat-contacts placeholder and static mock fallback. Card stack now uses only real API matches

Removed the following fields from onboarding to be re-introduced as profile action cards later:

-Ethnicity: multi-select ethnicity options
-Prompts: 1-3 draggable prompt selectors with question + answer
-Clubs: Cornell clubs/organizations tags
-Social links: Instagram, Snapchat, LinkedIn, GitHub, personal website
-Interests: free-text interest tags
Updated backend api specification

Fixed onboarding "Next" button permanently disabled from step 9 onward — updated validateStep and handleNext/TOTAL_STEPS to reflect the 10 active steps

### Test Plan
Open the Home tab — confirm only real weekly match cards appear (no chat contacts or mock cards)
Go through the onboarding flow — confirm "Next" button works through all 10 steps without getting stuck
Notes

### Next Steps:

Once the profile cards are done, the removed onboarding fields will be surfaced as profile action cards in the Home tab feed so users can fill them out post-signup

**See onboarding demo here:** 
https://github.com/user-attachments/assets/76e94f2f-30da-41fc-a733-2d12881035fa

